### PR TITLE
TIFF Tag issues

### DIFF
--- a/hal4000/halLib/tiffwriter.py
+++ b/hal4000/halLib/tiffwriter.py
@@ -111,6 +111,7 @@ class TiffWriter:
         self.writeTag(BitsPerSample, "short", 1, 8 * self.bytes_per_pixel)
         self.writeTag(Compression, "short", 1, 1)
         self.writeTag(PhotometricInterpretation, "short", 1, 1)
+        self.writeTag(ImageDescription, "ascii", len(self.imagej_desc), imagej_offset)
         self.writeTag(StripOffsets, "long", 1, image_offset)
         self.writeTag(SamplesPerPixel, "short", 1, 1)
         self.writeTag(RowsPerStrip, "long", 1, y_size)
@@ -120,7 +121,6 @@ class TiffWriter:
         self.writeTag(ResolutionUnit, "short", 1, 1)
         self.writeTag(Software, "ascii", len(self.software), software_offset)
         self.writeTag(DateTime, "ascii", len(self.date_time), datetime_offset)
-        self.writeTag(ImageDescription, "ascii", len(self.imagej_desc), imagej_offset)
 
         # Next IFD offset (4 bytes)
         self.last_ifd_offset = self.fp.tell()


### PR DESCRIPTION
TIFFReadDirectoryCheckOrder: Warning, Invalid TIFF directory; tags are not sorted in ascending order.
TIFFFetchNormalTag: Warning, ASCII value for tag "ImageDescription" does not end in null byte.

1) Sorting the tags w.r.t. tag# helped us, i.e. Image description comes after PhotometricInterpretation
2) Would modifying line 66 help?         self.imagej_desc = "ImageJ=1.49i\nunit=um\x00"