### PR TITLE
Python3 pyqt5 - hamamtsu controller updates

### DIFF
--- a/storm_control/hal4000/camera/hamamatsuCameraControl.py
+++ b/storm_control/hal4000/camera/hamamatsuCameraControl.py
@@ -166,6 +166,24 @@ class HamamatsuCameraControl(cameraControl.HWCameraControl):
                 
             self.camera_functionality.parametersChanged.emit()
 
+    def startFilm(self, film_settings, is_time_base):
+        super().startFilm(film_settings, is_time_base)
+        if self.camera_working:
+            if self.film_length is not None:
+                if (self.film_length > 1000):
+                    self.camera.setACQMode("run_till_abort")
+                else:
+                    self.camera.setACQMode(
+                            "fixed_length", 
+                            number_frames = self.film_length)
+            else:
+                self.camera.setACQMode("run_till_abort")
+
+    def stopFilm(self):
+        super().stopFilm()
+        if self.camera_working:
+            self.camera.setACQMode("run_till_abort")
+
 #
 # The MIT License
 #

--- a/storm_control/hal4000/focusLock/lockModes.py
+++ b/storm_control/hal4000/focusLock/lockModes.py
@@ -174,10 +174,6 @@ class LockedMixin(object):
                                     name = "minimum_sum",
                                     value = -1.0))
 
-        p.add(params.ParameterFloat(description = "Gain for focus lock feedback loop",
-                name = "gain",
-                value = -0.9))
-
     def getLockTarget(self):
         return self.lm_target
         
@@ -218,7 +214,6 @@ class LockedMixin(object):
         self.lm_counter = 0
         self.lm_min_sum = p.get("minimum_sum")
         self.lm_offset_threshold = 1.0e-3 * p.get("offset_threshold")
-        self.lm_gain = p.get("gain")
 
     def startLock(self):
         self.lm_counter = 0

--- a/storm_control/sc_hardware/hamamatsu/hamamatsu_camera.py
+++ b/storm_control/sc_hardware/hamamatsu/hamamatsu_camera.py
@@ -650,7 +650,7 @@ class HamamatsuCamera(object):
         else:
             self.setPropertyValue("subarray_mode", "ON")
 
-    def setAcquisitionMode(self, mode, number_frames = None):
+    def setACQMode(self, mode, number_frames = None):
         '''
         Set the acquisition mode to either run until aborted or to 
         stop after acquiring a set number of frames.

--- a/storm_control/sc_hardware/hamamatsu/hamamatsu_camera.py
+++ b/storm_control/sc_hardware/hamamatsu/hamamatsu_camera.py
@@ -254,7 +254,7 @@ class HamamatsuCamera(object):
         # Set up wait handle
         paramwait = DCAMWAIT_OPEN(0, 0, None, self.camera_handle)
         paramwait.size = ctypes.sizeof(paramwait)
-        self.checkStatus(dcam.dcamwait_open(paramwait), 
+        self.checkStatus(dcam.dcamwait_open(ctypes.byref(paramwait)), 
                 "dcamwait_open")
         self.wait_handle = paramwait.hwait
 
@@ -379,6 +379,7 @@ class HamamatsuCamera(object):
                              "dcam_unlockdata")
 
             frames.append(hc_data)
+
 
         return [frames, [self.frame_x, self.frame_y]]
 
@@ -784,6 +785,7 @@ class HamamatsuCameraMR(HamamatsuCamera):
         """
         self.captureSetup()
 
+
         #
         # Allocate new image buffers if necessary.
         # Allocate as many frames as can fit in 2GB of memory.
@@ -798,8 +800,6 @@ class HamamatsuCameraMR(HamamatsuCamera):
             else:
                 self.number_image_buffers = n_buffers
 
-
-            self.number_image_buffers = 10
 
             # Allocate new image buffers.
             ptr_array = ctypes.c_void_p * self.number_image_buffers
@@ -817,6 +817,7 @@ class HamamatsuCameraMR(HamamatsuCamera):
         # We need to attach & release for each acquisition otherwise
         # we'll get an error if we try to change the ROI in any way
         # between acquisitions.
+
 
         paramattach = DCAMBUF_ATTACH(0, DCAMBUF_ATTACHKIND_FRAME,
                 self.hcam_ptr, self.number_image_buffers)
@@ -843,6 +844,7 @@ class HamamatsuCameraMR(HamamatsuCamera):
         """
         Stop data acquisition and release the memory associates with the frames.
         """
+
 
         # Stop acquisition.
         self.checkStatus(dcam.dcamcap_stop(self.camera_handle),
@@ -929,7 +931,7 @@ if (__name__ == "__main__"):
             print("Testing run till abort acquisition")
             hcam.startAcquisition()
             cnt = 0
-            for i in range(30000):
+            for i in range(300):
                 [frames, dims] = hcam.getFrames()
                 for aframe in frames:
                     print(cnt, aframe[0:5])
@@ -942,10 +944,10 @@ if (__name__ == "__main__"):
         if True:
             for j in range (10):
                 print("Testing fixed length acquisition")
-                hcam.setAcquisitionMode("fixed_length", number_frames = 10)
+                hcam.setACQMode("fixed_length", number_frames = 10)
                 hcam.startAcquisition()
                 cnt = 0
-                for i in range(30000):
+                for i in range(10):
                     [frames, dims] = hcam.getFrames()
                     for aframe in frames:
                         print(cnt, aframe[0:5])


### PR DESCRIPTION
I updated the hamamatsu camera controller so that is uses the dcam4 API and implemented a fixed length mode where the camera automatically stops after a fixed, preset number of frames. I also removed the previously added gain parameter for the focus lock. 