### PR TITLE
Fixed problem storing the z stage position that has most recently achieved good focus

### DIFF
--- a/storm_control/hal4000/focusLock/lockModes.py
+++ b/storm_control/hal4000/focusLock/lockModes.py
@@ -230,7 +230,11 @@ class LockedMixin(object):
                 self.lm_buffer[self.lm_counter] = 0
 
             good_lock = bool(numpy.sum(self.lm_buffer) == self.lm_buffer_length)
-            self.last_good_z = self.z_stage_functionality.getCurrentPosition()
+
+            if good_lock:
+                self.last_good_z = \
+                        self.z_stage_functionality.getCurrentPosition()
+
             if (good_lock != self.good_lock):
                 self.setLockStatus(good_lock)
 


### PR DESCRIPTION
The focus lock previously saved the z stage position as good whenever the current state was measured, regardless of whether or not the focus was actually determined to be good. I changed it to save the stage z position as good only when the focus is good. 