### PR TITLE
Bug fix in focus lock scan functionality

### DIFF
--- a/storm_control/hal4000/focusLock/lockModes.py
+++ b/storm_control/hal4000/focusLock/lockModes.py
@@ -349,7 +349,7 @@ class ScanMixin(object):
         if (self.behavior == self.sm_mode_name):
             
             diff = 2.0 * self.sm_offset_threshold
-            if (qpd_state["sum"] > self.sm_min_sum):
+            if ((qpd_state["sum"] > self.sm_min_sum) and (qpd_state["is_good"]==True)):
                 diff = (qpd_state["offset"] - self.sm_target)
             
             #


### PR DESCRIPTION
We identified a problem in which the focus lock fails to properly scan for the focus if the lock target is close to zero.  The problem appears to be that when it starts the scan, no spots are present on the camera; thus, the qpd returns an 'is_good' dictionary element of False and an 'offset' element of zero.  However, if the desired lock target is too close to zero, the default offset value is considered 'in focus' and the scan stops immediately in the wrong focal plane. 

The solution we propose is to check theis_good element of the qpd_state.  If this element is not true, the scan continues independent of the 'offset' value. 