### PR TITLE
Added blackfly support to FLIR camera class

### DIFF
--- a/storm_control/hal4000/camera/pointgreyCameraControl.py
+++ b/storm_control/hal4000/camera/pointgreyCameraControl.py
@@ -34,50 +34,46 @@ class PointGreyCameraControl(cameraControl.HWCameraControl):
 
         # Get the camera & set some defaults.
         self.camera = spinnaker.getCamera(config.get("camera_id"))
-
-        # In order to turn off pixel defect correction the camera has
-        # to be in video mode 0.
-        self.camera.setProperty("VideoMode", "Mode0")
-        self.camera.setProperty("pgrDefectPixelCorrectionEnable", False)
-        
-        # Set pixel format.
-        #self.camera.setProperty("PixelFormat", "Mono12Packed")
-        #self.camera.setProperty("PixelFormat", "Mono12p")
-        self.camera.setProperty("PixelFormat", "Mono16")
-
-        self.camera.setProperty("VideoMode", config.get("video_mode"))
+          
+        # Set FLIR-specific camera properties to control relationship between
+        # exposure time and frame rate: This dictionary will allow extension in the future if needed
+        self.exposure_control = {"CameraControlExposure": True}
+          
+        # Extract preset values if provided
+        if config.has("presets"):
+            # Extract preset values
+            presets = config.get("presets")
+            
+            print("Configuring preset values of spinnaker camera: " + str(config.get("camera_id")))
+            
+            # Loop over values and set them
+            for p_name in presets.getAttrs():
+                if self.camera.hasProperty(p_name): # Confirm the camera has the property and warn if not
+                    p_value = presets.get(p_name)
+                    self.camera.setProperty(p_name, p_value) # Set value
+                    set_value = self.camera.getProperty(p_name).getValue() # Check set
+                    print("   " + str(p_name) + ": " + str(p_value) + " (" + str(set_value) + ")")
+                else:
+                    if p_name not in self.exposure_control.keys():
+                        print("!!!! preset " + str(p_name) + " is not a valid parameter for this camera")
+            
+            # Set the exposure-frame-rate-control parameters
+            self.exposure_control["CameraControlExposure"] = presets.get("CameraControlExposure", True)
+            print("Set exposure control properties:")
+            for key in self.exposure_control.keys():
+                print("   " + str(key) + ": " + str(self.exposure_control[key]))
                 
-        # We don't want any of these 'features'.
-        self.camera.setProperty("AcquisitionFrameRateAuto", "Off")
-        self.camera.setProperty("ExposureAuto", "Off")
-        self.camera.setProperty("GainAuto", "Off")        
-
-        if self.camera.hasProperty("pgrExposureCompensationAuto"):
-            self.camera.setProperty("pgrExposureCompensationAuto", "Off")
-
-        if self.camera.hasProperty("BlackLevelClampingEnable"):
-            self.camera.setProperty("BlackLevelClampingEnable", False)
-
-        if self.camera.hasProperty("SharpnessEnabled"):
-            self.camera.setProperty("SharpnessEnabled", False)
-
-        if self.camera.hasProperty("GammaEnabled"):
-            self.camera.setProperty("GammaEnabled", False)
-
-        #
-        # No idea what this means in the context of a black and white
-        # camera. We try and turn it off but that seems to be much
-        # harder to do than one would hope.
-        #
-        self.camera.setProperty("OnBoardColorProcessEnabled", False)
-
+        else:
+            print("No presets provided for spinnaker camera: " + str(config.get("camera_id")))
+        
         # Verify that we have turned off some of these 'features'.
-        for feature in ["pgrDefectPixelCorrectionEnable",
-                        "BlackLevelClampingEnable",
-                        "SharpnessEnabled",
-                        "GammaEnabled"]:
-            if self.camera.hasProperty(feature):
-                assert not self.camera.getProperty(feature).getValue()
+        ## REMOVED THIS BLOCK AS IT IS CAMERA SPECIFIC
+        #for feature in ["pgrDefectPixelCorrectionEnable",
+        #                "BlackLevelClampingEnable",
+        #                "SharpnessEnabled",
+        #                "GammaEnabled"]:
+        #    if self.camera.hasProperty(feature):
+        #        assert not self.camera.getProperty(feature).getValue()
 
         # Configure 'master' cameras to not use triggering.
         #
@@ -95,8 +91,8 @@ class PointGreyCameraControl(cameraControl.HWCameraControl):
             self.camera.setProperty("LineSource", "ExposureActive")
 
         # Configure 'slave' cameras to use triggering.
-        #
         # We are following: http://www.ptgrey.com/KB/11052
+        #
         # "Configuring Synchronized Capture with Multiple Cameras"
         #
         # Also, we connected the master camera to the DAQ card
@@ -135,9 +131,10 @@ class PointGreyCameraControl(cameraControl.HWCameraControl):
             self.parameters.add(params.ParameterRangeFloat(description = "Acquisition frame rate (FPS)",
                                                            name = "AcquisitionFrameRate",
                                                            value = 10.0,
-                                                           max_value = 500.0,
+                                                           max_value = self.camera.getProperty("AcquisitionFrameRate").getMaximum(),
                                                            min_value = self.camera.getProperty("AcquisitionFrameRate").getMinimum()))
-
+                                                           
+            
         # Slave cameras can set "ExposureTime".
         #
         # FIXME? If this is too large then the slave will be taking images
@@ -293,9 +290,23 @@ class PointGreyCameraControl(cameraControl.HWCameraControl):
 
             # For master cameras, set the exposure time to be the maximum given the current frame rate.
             if self.is_master:
-                self.camera.setProperty("ExposureTime", self.camera.getProperty("ExposureTime").getMaximum())
+                #self.camera.setProperty("ExposureTime", self.camera.getProperty("ExposureTime").getMaximum())
+                #self.parameters.setv("exposure_time", 1.0e-6 * self.camera.getProperty("ExposureTime").getValue())
+                                
+                                
+                # Update the frame rate
+                fps = self.camera.getProperty("AcquisitionFrameRate").getValue()
+                self.parameters.setv("fps", fps)
+                
+                # Set the exposure time
+                if self.exposure_control["CameraControlExposure"]: # Camera determines maximum exposure time
+                    max_exposure = self.camera.getProperty("ExposureTime").getMaximum()
+                else: 
+                    max_exposure = 1e6/fps # Calculate theoretical max in microseconds
+                self.camera.setProperty("ExposureTime", max_exposure)
+
+                # Update the parameters to reflect the real value
                 self.parameters.setv("exposure_time", 1.0e-6 * self.camera.getProperty("ExposureTime").getValue())
-                self.parameters.setv("fps", self.camera.getProperty("AcquisitionFrameRate").getValue())
 
             # For slave cameras, just copy 'ExposureTime' to 'exposure_time' for
             # the benefit of the camera parameters viewer.
@@ -337,8 +348,11 @@ class PointGreyCameraControl(cameraControl.HWCameraControl):
         super().stopCamera()
         if self.is_master:
             self.camera.setProperty("LineSelector", "Line1")
-            self.camera.setProperty("LineSource", "ExternalTriggerActive")
-        
+            if self.camera.hasProperty("VideoMode"):
+                self.camera.setProperty("LineSource", "ExternalTriggerActive")
+            else:
+                self.camera.setProperty("LineSource", "ExposureActive")
+
 #
 # The MIT License
 #

--- a/storm_control/hal4000/camera/pointgreyCameraControl.py
+++ b/storm_control/hal4000/camera/pointgreyCameraControl.py
@@ -131,7 +131,7 @@ class PointGreyCameraControl(cameraControl.HWCameraControl):
             self.parameters.add(params.ParameterRangeFloat(description = "Acquisition frame rate (FPS)",
                                                            name = "AcquisitionFrameRate",
                                                            value = 10.0,
-                                                           max_value = self.camera.getProperty("AcquisitionFrameRate").getMaximum(),
+                                                           max_value = 5000,
                                                            min_value = self.camera.getProperty("AcquisitionFrameRate").getMinimum()))
                                                            
             
@@ -266,7 +266,14 @@ class PointGreyCameraControl(cameraControl.HWCameraControl):
                     if (parameters.get(pname) > self.parameters.get(pname)):
                         self.camera.setProperty("OffsetX", parameters.get("OffsetX"))
 
-                self.camera.setProperty(pname, parameters.get(pname))
+                if (pname == "AcquisitionFrameRate"): #Coerce frame rate to range
+                    max_value = self.camera.getProperty(pname).getMaximum()
+                    min_value = self.camera.getProperty(pname).getMinimum()
+                    coerced_value = min(parameters.get(pname), max_value)
+                    coerced_value = max(coerced_value, min_value)
+                    self.camera.setProperty(pname, coerced_value)
+                else:
+                    self.camera.setProperty(pname, parameters.get(pname))
 
             #
             # Update properties, note that the allowed ranges of many

--- a/storm_control/hal4000/xml/1cam_blackfly.xml
+++ b/storm_control/hal4000/xml/1cam_blackfly.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<config>
+
+  <!-- The starting directory. -->
+  <directory type="directory">C:\Data\Temp\</directory>
+  
+  <!-- The setup name -->
+  <setup_name type="string">blackfly_test</setup_name>
+
+  <!-- The ui type, this is 'classic' or 'detached' -->
+  <ui_type type="string">detached</ui_type>
+
+  <!--
+      This has two effects:
+      
+      (1) If this is True any exception will immediately crash HAL, which can
+      be useful for debugging. If it is False then some exceptions will be
+      handled by the modules.
+      
+      (2) If it is False we also don't check whether messages are valid.
+  -->
+  <strict type="boolean">True</strict>
+  
+  <!--
+      Define the modules to use for this setup.
+  -->
+  <modules>
+
+    <!--
+	This is the main window, you must have this.
+    -->
+    <hal>
+      <class_name type="string">HalController</class_name>
+      <module_name type="string">storm_control.hal4000.hal4000</module_name>
+    </hal>
+
+    <!--
+	You also need all of these.
+    -->
+
+    <!-- Camera display. -->
+    <display>
+      <class_name type="string">Display</class_name>
+      <module_name type="string">storm_control.hal4000.display.display</module_name>
+      <parameters>
+
+	<!-- The default color table. Other options are in hal4000/colorTables/all_tables -->
+	<colortable type="string">ramp.ctbl</colortable>
+	
+      </parameters>
+    </display>
+    
+    <!-- Feeds. -->
+    <feeds>
+      <class_name type="string">Feeds</class_name>
+      <module_name type="string">storm_control.hal4000.feeds.feeds</module_name>
+    </feeds>
+
+    <!-- Filming and starting/stopping the camera. -->
+    <film>
+      <class_name type="string">Film</class_name>
+      <module_name type="string">storm_control.hal4000.film.film</module_name>
+
+      <!-- Film parameters specific to this setup go here. -->
+      <parameters>
+	<extension desc="Movie file name extension" type="string" values=",Red,Green,Blue"></extension>
+      </parameters>
+    </film>
+
+    <!-- Which objective is being used, etc. -->
+    <mosaic>
+      <class_name type="string">Mosaic</class_name>
+      <module_name type="string">storm_control.hal4000.mosaic.mosaic</module_name>
+
+      <!-- List objectives available on this setup here. -->
+      <parameters>
+	<flip_horizontal desc="Flip image horizontal (mosaic)" type="boolean">False</flip_horizontal>
+	<flip_vertical desc="Flip image vertical (mosaic)" type="boolean">False</flip_vertical>
+	<transpose desc="Transpose image (mosaic)" type="boolean">False</transpose>
+
+	<objective desc="Current objective" type="string" values="obj1,obj2,obj3">obj1</objective>
+	<obj1 desc="Objective 1" type="custom">60x,0.120,0.0,0.0</obj1>
+      </parameters>
+    </mosaic>
+
+    <!-- Loading, changing and editting settings/parameters -->
+    <settings>
+      <class_name type="string">Settings</class_name>
+      <module_name type="string">storm_control.hal4000.settings.settings</module_name>
+    </settings>
+
+    <!-- Set the time base for films. -->
+    <timing>
+      <class_name type="string">Timing</class_name>
+      <module_name type="string">storm_control.hal4000.timing.timing</module_name>
+      <parameters>
+	<time_base type="string">camera1</time_base>
+      </parameters>
+    </timing>
+  
+    <!--
+	Everything else is optional, but you probably want at least one camera.
+    -->
+
+    <!-- Camera control. -->
+    <!--
+	Note that the cameras must have the names "camera1", "camera2", etc..
+	
+	Cameras are either "master" (they provide their own hardware timing)
+	or "slave" they are timed by another camera. Each time the cameras
+	are started the slave cameras are started first, then the master cameras.
+    -->
+
+    <camera1>
+      <class_name type="string">Camera</class_name>
+      <module_name type="string">storm_control.hal4000.camera.camera</module_name>
+      <camera>
+	<master type="boolean">True</master>
+	<class_name type="string">PointGreyCameraControl</class_name>
+	<module_name type="string">storm_control.hal4000.camera.pointgreyCameraControl</module_name>
+	<parameters>
+	  <!-- Which camera to use -->
+	  <camera_id type="string">20067703</camera_id>
+	  
+	  <!-- Preset values - camera specific values that are fixed -->
+	  <presets>
+		<!-- FLIR camera general properties -->
+        <PixelFormat type="string">Mono16</PixelFormat> <!-- Mono12Packed/Mono12p -->
+		<ExposureAuto type="string">Off</ExposureAuto>
+		<GainAuto type="string">Off</GainAuto>
+		<BlackLevelClampingEnable type="boolean">False</BlackLevelClampingEnable>
+		
+		<!-- Blackfly specific properties --> 
+		<AcquisitionFrameRateEnable type="boolean">True</AcquisitionFrameRateEnable>
+
+		<!-- Properties to control relationship between exposure and frame rate -->
+		<CameraControlExposure type="boolean">False</CameraControlExposure>
+
+		<!-- Invalid parameter to test warning --> 
+		<test_parameter type="string">Test Value</test_parameter>
+	  </presets>
+	  
+	  <!-- These are the display defaults, not the camera range. -->
+	  <default_max type="int">200</default_max> 
+	  <default_min type="int">30</default_min>
+	  <flip_horizontal type="boolean">False</flip_horizontal>
+	  <flip_vertical type="boolean">False</flip_vertical>
+	  <transpose type="boolean">True</transpose>
+
+	  <!-- These can be changed / editted. -->
+
+	  <!-- This is the extension to use (if any) when saving data from this camera. -->
+	  <extension type="string">c1</extension>
+	  
+	  <!-- Whether or not data from this camera is saved during filming. -->
+	  <saved type="boolean">True</saved>
+
+	</parameters>
+      </camera>
+    </camera1>
+    
+    
+  </modules>  
+</config>

--- a/storm_control/hal4000/xml/1cam_grasshopper.xml
+++ b/storm_control/hal4000/xml/1cam_grasshopper.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<config>
+
+  <!-- The starting directory. -->
+  <directory type="directory">C:\Data\Temp\</directory>
+  
+  <!-- The setup name -->
+  <setup_name type="string">grasshopper_test</setup_name>
+
+  <!-- The ui type, this is 'classic' or 'detached' -->
+  <ui_type type="string">detached</ui_type>
+
+  <!--
+      This has two effects:
+      
+      (1) If this is True any exception will immediately crash HAL, which can
+      be useful for debugging. If it is False then some exceptions will be
+      handled by the modules.
+      
+      (2) If it is False we also don't check whether messages are valid.
+  -->
+  <strict type="boolean">True</strict>
+  
+  <!--
+      Define the modules to use for this setup.
+  -->
+  <modules>
+
+    <!--
+	This is the main window, you must have this.
+    -->
+    <hal>
+      <class_name type="string">HalController</class_name>
+      <module_name type="string">storm_control.hal4000.hal4000</module_name>
+    </hal>
+
+    <!--
+	You also need all of these.
+    -->
+
+    <!-- Camera display. -->
+    <display>
+      <class_name type="string">Display</class_name>
+      <module_name type="string">storm_control.hal4000.display.display</module_name>
+      <parameters>
+
+	<!-- The default color table. Other options are in hal4000/colorTables/all_tables -->
+	<colortable type="string">ramp.ctbl</colortable>
+	
+      </parameters>
+    </display>
+    
+    <!-- Feeds. -->
+    <feeds>
+      <class_name type="string">Feeds</class_name>
+      <module_name type="string">storm_control.hal4000.feeds.feeds</module_name>
+    </feeds>
+
+    <!-- Filming and starting/stopping the camera. -->
+    <film>
+      <class_name type="string">Film</class_name>
+      <module_name type="string">storm_control.hal4000.film.film</module_name>
+
+      <!-- Film parameters specific to this setup go here. -->
+      <parameters>
+	<extension desc="Movie file name extension" type="string" values=",Red,Green,Blue"></extension>
+      </parameters>
+    </film>
+
+    <!-- Which objective is being used, etc. -->
+    <mosaic>
+      <class_name type="string">Mosaic</class_name>
+      <module_name type="string">storm_control.hal4000.mosaic.mosaic</module_name>
+
+      <!-- List objectives available on this setup here. -->
+      <parameters>
+	<flip_horizontal desc="Flip image horizontal (mosaic)" type="boolean">False</flip_horizontal>
+	<flip_vertical desc="Flip image vertical (mosaic)" type="boolean">False</flip_vertical>
+	<transpose desc="Transpose image (mosaic)" type="boolean">False</transpose>
+
+	<objective desc="Current objective" type="string" values="obj1,obj2,obj3">obj1</objective>
+	<obj1 desc="Objective 1" type="custom">60x,0.120,0.0,0.0</obj1>
+      </parameters>
+    </mosaic>
+
+    <!-- Loading, changing and editting settings/parameters -->
+    <settings>
+      <class_name type="string">Settings</class_name>
+      <module_name type="string">storm_control.hal4000.settings.settings</module_name>
+    </settings>
+
+    <!-- Set the time base for films. -->
+    <timing>
+      <class_name type="string">Timing</class_name>
+      <module_name type="string">storm_control.hal4000.timing.timing</module_name>
+      <parameters>
+	<time_base type="string">camera1</time_base>
+      </parameters>
+    </timing>
+  
+    <!--
+	Everything else is optional, but you probably want at least one camera.
+    -->
+
+    <!-- Camera control. -->
+    <!--
+	Note that the cameras must have the names "camera1", "camera2", etc..
+	
+	Cameras are either "master" (they provide their own hardware timing)
+	or "slave" they are timed by another camera. Each time the cameras
+	are started the slave cameras are started first, then the master cameras.
+    -->
+
+    <camera1>
+      <class_name type="string">Camera</class_name>
+      <module_name type="string">storm_control.hal4000.camera.camera</module_name>
+      <camera>
+	<master type="boolean">True</master>
+	<class_name type="string">PointGreyCameraControl</class_name>
+	<module_name type="string">storm_control.hal4000.camera.pointgreyCameraControl</module_name>
+	<parameters>
+	  <!-- Which camera to use -->
+	  <camera_id type="string">16492137</camera_id>
+	  
+	  <!-- Preset values - camera specific values that are fixed -->
+	  <presets>
+		<!-- FLIR camera general properties -->
+        <PixelFormat type="string">Mono16</PixelFormat> <!-- Mono12Packed/Mono12p -->
+		<ExposureAuto type="string">Off</ExposureAuto>
+		<GainAuto type="string">Off</GainAuto>
+		<BlackLevelClampingEnable type="boolean">False</BlackLevelClampingEnable>
+		
+		<!-- Grasshopper specific properties --> 
+        <VideoMode type="string">Mode7</VideoMode>   
+        <pgrDefectPixelCorrectionEnable type="boolean">False</pgrDefectPixelCorrectionEnable>
+		<AcquisitionFrameRateAuto type="string">Off</AcquisitionFrameRateAuto>
+		<pgrExposureCompensationAuto type="string">Off</pgrExposureCompensationAuto>
+		<GammaEnabled type="boolean">False</GammaEnabled>
+		<OnBoardColorProcessEnabled type="boolean">False</OnBoardColorProcessEnabled>
+
+		<!-- Properties to control relationship between exposure and frame rate -->
+		<CameraControlExposure type="boolean">True</CameraControlExposure>
+		
+		<!-- Invalid parameter to test warning --> 
+		<test_parameter type="string">Test Value</test_parameter>
+	  </presets>
+
+	  <!--
+	      What value to use for Trigger Activation, 'RisingEdge' or
+	      'FallingEdge'. 'FallingEdge' is the default if not specified.
+	  -->
+	  <trigger_activation type="string">RisingEdge</trigger_activation>	  
+
+	  <!-- These are the display defaults, not the camera range. -->
+	  <default_max type="int">200</default_max> 
+	  <default_min type="int">30</default_min>
+	  <flip_horizontal type="boolean">False</flip_horizontal>
+	  <flip_vertical type="boolean">False</flip_vertical>
+	  <transpose type="boolean">True</transpose>
+
+	  <!-- These can be changed / editted. -->
+
+	  <!-- This is the extension to use (if any) when saving data from this camera. -->
+	  <extension type="string">c1</extension>
+	  
+	  <!-- Whether or not data from this camera is saved during filming. -->
+	  <saved type="boolean">True</saved>
+
+	</parameters>
+      </camera>
+    </camera1>
+    
+    
+  </modules>  
+</config>


### PR DESCRIPTION
The blackfly and grasshopper cameras have a slightly different parameter sets and handle exposure times differently.  I made the following changes to address these issues:

1) Camera-specific values are now set by a <presets> element in the config.xml file. I have provided an example for a blackfly and for a grasshopper.

2) There is a parameter that controls how the camera sets its maximum exposure time. 

3) Different valid values for 'LineSource' are handled by checking a camera-specific parameter. There is probably a more elegant solution to this issue.  

I also fixed a minor 'bug' in the maximum frame rate wherein the cameras can crash the first time a frame rate is requested if it is larger than the hardware maximum. 

All changes were tested with a grasshopper and a blackfly camera. 