### PR TITLE
Updated hardwareTiming to report fps in xml files

### DIFF
--- a/storm_control/hal4000/timing/hardwareTiming.py
+++ b/storm_control/hal4000/timing/hardwareTiming.py
@@ -221,3 +221,9 @@ class HardwareTiming(halModule.HalModule):
             if message.getData()["master"]:
                 self.hardware_timing_functionality.stopCounter()
                 
+        elif message.isType("stop film"):
+            message.addResponse(halMessage.HalMessageResponse(source = self.module_name, 
+                                                              data = {"parameters" : self.parameters.copy()}))
+                
+                
+                


### PR DESCRIPTION
Added some code to handle the 'stop film' message in the hardwareTiming class. This update allows this module to save its settings in the xml files associated with each movie.