### PR TITLE
Fixed a bug introduced in the most recent version of tifffile

### DIFF
--- a/storm_control/hal4000/halLib/imagewriters.py
+++ b/storm_control/hal4000/halLib/imagewriters.py
@@ -229,7 +229,8 @@ class TIFFile(BaseFileWriter):
         image = frame.getData()
         self.tif.save(image.reshape((frame.image_y, frame.image_x)),
                       metadata = self.metadata,
-                      resolution = self.resolution)
+                      resolution = self.resolution, 
+                      contiguous = True)
 
 
 #


### PR DESCRIPTION
The most recent version of tifffile changed a default setting for saving tiff files. Now the contiguous setting is assumed to be False unless otherwise specified. In this pull request, I assign the contiguous flag to True (the former default) in imagewriters.py.