### PR TITLE
Upgraded dave to allow the detection of lost movies if requested

### DIFF
--- a/storm_control/dave/test/test_recipe.xml
+++ b/storm_control/dave/test/test_recipe.xml
@@ -161,6 +161,15 @@
        <variable_entry name = "Movie Loop" />
     </movie> 
 	
+	<!-- Add a timer (in minutes) to capture a hardware failure if movie takes longer than the timer -->
+    <movie>
+       <name increment="Yes">No_Parameters_ErrorCheck</name>
+       <length>300</length>
+	   <failure_duration>1</failure_duration>
+       <variable_entry name = "Movie Loop" />
+    </movie>
+
+	
 	<!-- Clear warnings-->
     <clear_warnings/>
 	

--- a/storm_control/dave/xml_generators/nodeToDict.py
+++ b/storm_control/dave/xml_generators/nodeToDict.py
@@ -61,7 +61,8 @@ movie_node_conversion = {"delay" : gf("delay", [int]),
                          "progression" : gf("progression", [None]),
                          "recenter" : gf("recenter", [boolConv]),
                          "stage_x" : gf("stage_x", [float]),
-                         "stage_y" : gf("stage_y", [float])}
+                         "stage_y" : gf("stage_y", [float]), 
+                         "failure_duration" : gf("failure_duration", [int])}
 
 ## movieNodeToDict
 #


### PR DESCRIPTION
This upgrade adds a new parameter that can be configured in a Dave movie request.  If the 	   <failure_duration>num</failure_duration> tag is added to a movie request in a dave recipe, Dave will issue an error if hal does not respond after 'N' minutes.  This minor addition can be useful for notifying the user if there has been a crash. 


