### PR TITLE
Added changes to allow display control over ir laser GUI controls

### DIFF
--- a/storm_control/hal4000/focusLock/lockDisplay.py
+++ b/storm_control/hal4000/focusLock/lockDisplay.py
@@ -94,14 +94,19 @@ class LockDisplay(QtWidgets.QGroupBox):
         if (name == "ir_laser"):
             self.ir_laser_functionality = functionality
             
-            self.ui.irButton.show()
-            self.ui.irButton.clicked.connect(self.handleIrButton)
-            if self.ir_laser_functionality.hasPowerAdjustment():
-                self.ui.irSlider.setMaximum(self.ir_laser_functionality.getMaximum())
-                self.ui.irSlider.setMinimum(self.ir_laser_functionality.getMinimum())
-                self.ui.irSlider.setValue(self.ir_power)
-                self.ui.irSlider.show()
-                self.ui.irSlider.valueChanged.connect(self.handleIrSlider)
+            if self.ir_laser_functionality.shouldDisplay():
+                self.ui.irButton.show()
+                self.ui.irButton.clicked.connect(self.handleIrButton)
+                if self.ir_laser_functionality.hasPowerAdjustment():
+                    self.ui.irSlider.setMaximum(self.ir_laser_functionality.getMaximum())
+                    self.ui.irSlider.setMinimum(self.ir_laser_functionality.getMinimum())
+                    self.ui.irSlider.setValue(self.ir_power)
+                    self.ui.irSlider.show()
+                    self.ui.irSlider.valueChanged.connect(self.handleIrSlider)
+            else:
+                self.ui.irButton.hide()
+                self.ui.irSlider.hide()
+
         elif (name == "qpd"):
             self.q_qpd_offset_display.setFunctionality(functionality)
             self.q_qpd_sum_display.setFunctionality(functionality)

--- a/storm_control/hal4000/xml/none_config.xml
+++ b/storm_control/hal4000/xml/none_config.xml
@@ -375,6 +375,9 @@
     <none_irlaser>
       <module_name type="string">storm_control.sc_hardware.none.noneIRLaserModule</module_name>
       <class_name type="string">NoneIRLaserModule</class_name>
+	  <configuration>
+		<display_controls type="boolean">False</display_controls>
+	  </configuration>
     </none_irlaser>
     
     <none_qpd>

--- a/storm_control/sc_hardware/baseClasses/amplitudeModule.py
+++ b/storm_control/sc_hardware/baseClasses/amplitudeModule.py
@@ -77,7 +77,15 @@ class AmplitudeMixin(object):
         do what ever they need to do to get ready for filming.
         """
         assert False
-        
+
+    def shouldDisplay(self):
+        """
+        This method allows some amplitude functionalities to control whether or not GUI-associated user controls 
+        are displayed.  The default is to always display. To turn this off or allow control over this property
+        from a configuration file, this method must be overwritten. 
+        """
+        return True
+    
     
 class AmplitudeFunctionality(hardwareModule.HardwareFunctionality, AmplitudeMixin):
     """
@@ -124,3 +132,5 @@ class AmplitudeModule(hardwareModule.HardwareModule):
 
     def stopFilm(self, message):
         pass
+
+

--- a/storm_control/sc_hardware/none/noneIRLaserModule.py
+++ b/storm_control/sc_hardware/none/noneIRLaserModule.py
@@ -12,9 +12,10 @@ import storm_control.sc_hardware.baseClasses.amplitudeModule as amplitudeModule
 
 class NoneIRLaserFunctionality(amplitudeModule.AmplitudeFunctionality):
 
-    def __init__(self, **kwds):
+    def __init__(self, display_controls = True, **kwds):
         super().__init__(**kwds)
         self.scale = 1.0/(self.maximum - self.minimum + 1.0)
+        self.display_controls = display_controls
 
     def hasPowerAdjustment(self):
         return True
@@ -25,15 +26,24 @@ class NoneIRLaserFunctionality(amplitudeModule.AmplitudeFunctionality):
     def output(self, power):
         duty_cycle = (power - self.minimum)*self.scale
 
+    def shouldDisplay(self):
+        return self.display_controls
+
 
 class NoneIRLaserModule(amplitudeModule.AmplitudeModule):
 
     def __init__(self, module_params = None, qt_settings = None, **kwds):
         super().__init__(**kwds)
+        try:
+            self.configuration = module_params.get("configuration")
+            display_controls = self.configuration.get("display_controls", True)
+        except:
+            display_controls = True
 
         self.ir_laser_functionality = NoneIRLaserFunctionality(minimum = 0,
                                                                maximum = 100,
-                                                               used_during_filming = False)
+                                                               used_during_filming = False, 
+                                                               display_controls = display_controls)
         
     def getFunctionality(self, message):
         if (message.getData()["name"] == self.module_name):


### PR DESCRIPTION
This pull request adds the ability to turn off the IR laser on/off button and power control in the focuslock GUI.  There are scope configurations in which the IR laser is simply controlled by the power supply and there is no need for hal-based control over the IR laser power. In these cases, it is convenient to be able to turn off the display of these controls. 