### PR TITLE
Clean up of a upgrade the Hamamatsu Camera classes to configure camer…

### DIFF
--- a/storm_control/sc_hardware/hamamatsu/hamamatsu_camera.py
+++ b/storm_control/sc_hardware/hamamatsu/hamamatsu_camera.py
@@ -303,7 +303,7 @@ class HamamatsuCamera(object):
 
         # Get camera properties.
         self.properties = self.getCameraProperties()
-
+                
         # Get camera max width, height.
         self.max_width = self.getPropertyValue("image_width")[0]
         self.max_height = self.getPropertyValue("image_height")[0]
@@ -819,6 +819,10 @@ class HamamatsuCameraMR(HamamatsuCamera):
         self.hcam_data = []
         self.hcam_ptr = False
         self.old_frame_bytes = -1
+
+        # Configure all cameras to allow input triggers (for multi-camera control)
+        self.setPropertyValue("output_trigger_kind[0]", "EXPOSURE")
+        self.setPropertyValue("output_trigger_polarity[0]", "POSITIVE")
 
     def getFrames(self):
         """


### PR DESCRIPTION
These minor changes to the hamamatsu camera control classes set the trigger pins such that every camera can be triggered by an external 'fire/exposure' signal. This change allows multiple cameras to be coordinated by using an external trigger signal from one to trigger other cameras. 

As an example, two camera systems can be configured by adding the following flags to configuration xml file.  For the control camera: 

		  <!-- Trigger properties of the camera -->
		  <trigger_source type="string">INTERNAL</trigger_source>
  		  <trigger_polarity type="string">POSITIVE</trigger_polarity>
		  <trigger_active type="string">SYNCREADOUT</trigger_active>

For the worker camera:
  		  <!-- Trigger properties of the camera -->
		  <trigger_source type="string">EXTERNAL</trigger_source>
  		  <trigger_polarity type="string">POSITIVE</trigger_polarity>
		  <trigger_active type="string">SYNCREADOUT</trigger_active>
