### PR TITLE
Added the ability to turn off drag capabilities in hal display

### DIFF
--- a/storm_control/hal4000/display/cameraFrameViewer.py
+++ b/storm_control/hal4000/display/cameraFrameViewer.py
@@ -96,7 +96,7 @@ class CameraFrameViewer(QtWidgets.QFrame):
     feedChange = QtCore.pyqtSignal(str)
     guiMessage = QtCore.pyqtSignal(object)
 
-    def __init__(self, display_name = None, feed_name = "camera1", default_colortable = None, **kwds):
+    def __init__(self, display_name = None, feed_name = "camera1", default_colortable = None, can_drag = False, **kwds):
         super().__init__(**kwds)
 
         # General (alphabetically ordered).
@@ -117,6 +117,7 @@ class CameraFrameViewer(QtWidgets.QFrame):
         self.show_info = True
         self.show_target = False
         self.stage_functionality = None
+        self.can_drag = can_drag # Can the user drag
 
         #
         # Keep track of the default feed_name in the default parameters, these
@@ -176,9 +177,11 @@ class CameraFrameViewer(QtWidgets.QFrame):
         self.camera_view.newScale.connect(self.handleNewScale)
         self.camera_view.verticalScrollBar().sliderReleased.connect(self.handleScrollBar)
 
-        self.camera_view.dragMove.connect(self.handleDragMove)
-        self.camera_view.dragStart.connect(self.handleDragStart)
-        self.camera_view.rubberBandChanged.connect(self.handleRubberBandChanged)
+        # Connect the drag signals if this option is available
+        if self.can_drag:
+            self.camera_view.dragMove.connect(self.handleDragMove)
+            self.camera_view.dragStart.connect(self.handleDragStart)
+            self.camera_view.rubberBandChanged.connect(self.handleRubberBandChanged)
 
         self.ui.autoScaleButton.clicked.connect(self.handleAutoScale)
         self.ui.colorComboBox.currentIndexChanged[str].connect(self.handleColorTableChange)

--- a/storm_control/hal4000/display/cameraViewers.py
+++ b/storm_control/hal4000/display/cameraViewers.py
@@ -108,13 +108,14 @@ class ClassicViewer(QtCore.QObject, CameraParamsMixin):
     """
     guiMessage = QtCore.pyqtSignal(object)
 
-    def __init__(self, module_name = "", camera_name = "camera1", default_colortable = None, **kwds):
+    def __init__(self, module_name = "", camera_name = "camera1", default_colortable = None, can_drag = False, **kwds):
         super().__init__(**kwds)
         self.module_name = module_name
 
         self.frame_viewer = cameraFrameViewer.CameraFrameViewer(display_name = self.module_name,
                                                                 feed_name = camera_name,
-                                                                default_colortable = default_colortable)
+                                                                default_colortable = default_colortable,
+                                                                can_drag = can_drag)
         self.params_viewer = paramsViewer.ParamsViewer(viewer_name = self.module_name,
                                                        viewer_ui = cameraParamsUi)
 
@@ -170,12 +171,13 @@ class FeedViewer(halDialog.HalDialog, CameraParamsMixin):
     """
     guiMessage = QtCore.pyqtSignal(object)
     
-    def __init__(self, camera_name = "camera1", default_colortable = None, **kwds):
+    def __init__(self, camera_name = "camera1", default_colortable = None, can_drag = False, **kwds):
         super().__init__(**kwds)
 
         self.frame_viewer = cameraFrameViewer.CameraFrameViewer(display_name = self.module_name,
                                                                 feed_name = camera_name,
-                                                                default_colortable = default_colortable)
+                                                                default_colortable = default_colortable,
+                                                                can_drag = can_drag)
         self.params_viewer = None
 
         self.ui = feedViewerUi.Ui_Dialog()
@@ -195,12 +197,13 @@ class DetachedViewer(halDialog.HalDialog, CameraParamsMixin):
     """
     guiMessage = QtCore.pyqtSignal(object)
 
-    def __init__(self, camera_name = "camera1", default_colortable = None, **kwds):
+    def __init__(self, camera_name = "camera1", default_colortable = None, can_drag = False, **kwds):
         super().__init__(**kwds)
 
         self.frame_viewer = cameraFrameViewer.CameraFrameViewer(display_name = self.module_name,
                                                                 feed_name = camera_name,
-                                                                default_colortable = default_colortable)
+                                                                default_colortable = default_colortable, 
+                                                                can_drag = can_drag)
         self.params_viewer = paramsViewer.ParamsViewer(viewer_name = self.module_name,
                                                        viewer_ui = cameraParamsDetachedUi)
 

--- a/storm_control/hal4000/display/display.py
+++ b/storm_control/hal4000/display/display.py
@@ -41,10 +41,12 @@ class Display(halModule.HalModule):
         #
         if self.is_classic:
             self.viewers.append(cameraViewers.ClassicViewer(module_name = self.getNextViewerName(),
-                                                            default_colortable = self.parameters.get("colortable")))
+                                                            default_colortable = self.parameters.get("colortable"),
+                                                            can_drag = self.parameters.get("can_drag", default=False)))
         else:
             camera_viewer = cameraViewers.DetachedViewer(module_name = self.getNextViewerName(),
-                                                         default_colortable = self.parameters.get("colortable"))
+                                                         default_colortable = self.parameters.get("colortable"),
+                                                         can_drag = self.parameters.get("can_drag", default=False))
             camera_viewer.halDialogInit(self.qt_settings, self.window_title + " camera viewer")        
             self.viewers.append(camera_viewer)
         

--- a/storm_control/hal4000/xml/none_config.xml
+++ b/storm_control/hal4000/xml/none_config.xml
@@ -44,9 +44,10 @@
       <module_name type="string">storm_control.hal4000.display.display</module_name>
       <parameters>
 
-	<!-- The default color table. Other options are in hal4000/colorTables/all_tables -->
-	<colortable type="string">idl5.ctbl</colortable>
-	
+	  <!-- The default color table. Other options are in hal4000/colorTables/all_tables -->
+	  <colortable type="string">idl5.ctbl</colortable>
+	  <can_drag type="boolean">True</can_drag>
+
       </parameters>
     </display>
     


### PR DESCRIPTION
The hal camera display module has two functionalities that are not fully integrated (with all stages): drag to move the stage, and drag to select rectangles.  

Here we add a parameter to the display module in the configuration xml that can turn on or off these partially integrated functions.  By default this parameter is True as this was the default in previous hal versions.  
