### PR TITLE
Add explicit cast to integers

### DIFF
--- a/storm_control/hal4000/illumination/illuminationChannelUI.py
+++ b/storm_control/hal4000/illumination/illuminationChannelUI.py
@@ -192,7 +192,7 @@ class ChannelUIAdjustable(ChannelUI):
 
         page_step = 0.1 * (maximum - minimum)
         if (page_step > 1.0):
-            self.powerslider.setPageStep(page_step)
+            self.powerslider.setPageStep(int(page_step))
         self.powerslider.setSingleStep(1)
 
         #
@@ -236,7 +236,7 @@ class ChannelUIAdjustable(ChannelUI):
 
     def setAmplitude(self, amplitude):
         if (amplitude != self.powerslider.value()):
-            self.powerslider.setValue(amplitude)
+            self.powerslider.setValue(int(amplitude))
 
     def setupButtons(self, button_data):
 

--- a/storm_control/hal4000/settings/parametersEditorDialog.py
+++ b/storm_control/hal4000/settings/parametersEditorDialog.py
@@ -188,7 +188,7 @@ class EditorTreeViewDelegate(QtWidgets.QStyledItemDelegate):
         This provides a little more space between the items.
         """
         result = QtWidgets.QStyledItemDelegate.sizeHint(self, option, index)
-        result.setHeight(2.0 * result.height())
+        result.setHeight(int(2.0 * result.height()))
         return result
 
     def updateEditorGeometry(self, editor, option, index):

--- a/storm_control/hal4000/settings/parametersListView.py
+++ b/storm_control/hal4000/settings/parametersListView.py
@@ -52,7 +52,7 @@ class ParametersListViewDelegate(QtWidgets.QStyledItemDelegate):
         This provides a little more space between the items.
         """
         result = QtWidgets.QStyledItemDelegate.sizeHint(self, option, index)
-        result.setHeight(1.2 * result.height())
+        result.setHeight(int(1.2 * result.height()))
         return result
 
     


### PR DESCRIPTION
This  resolves issues with PyQt5 no longer silently converting floats. I imagine there are more of these..